### PR TITLE
Skip Unstable tests

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,9 +28,9 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -D environment=PROD
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml -D environment=PROD
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <!--region Configure Java version & Main full package and class name -->
         <!-- WARNING: add release scope if 1.9 and older versions are used at build/plugins/plugin/[maven-compiler-plugin]/configuration-->
         <java.version>8</java.version>
-        <main.class>org.white_sdev.template.logger_db_runnable_template.LoggerDbRunnableTemplate</main.class>
         <!--endregion-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -159,6 +158,39 @@
         <!-- endregion testing -->
 
     </dependencies>
+
+    <!-- region PROD Profile -->
+    <!-- Here used only to exclude Failing tests on production -->
+    <profiles>
+        <profile>
+            <id>prod-exclusions</id>
+            <activation>
+                <property>
+                    <name>environment</name>
+                    <value>PROD</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- region Maven is able to run JUnit5 Tests -->
+                    <!-- This requires junit-jupiter-engine [in junit-jupiter] dependency! -->
+                    <!-- This will run everything that Starts or ends with Test[(Case)|s]{0-1}. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M7</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.white_sdev.white_seleniumframework.framework.prodexcluded.**</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <!-- endregion -->
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <!-- endregion PROD Profile -->
 
     <build>
         <plugins>

--- a/src/test/java/org/white_sdev/white_seleniumframework/framework/prodexcluded/AutomationSuiteTest.java
+++ b/src/test/java/org/white_sdev/white_seleniumframework/framework/prodexcluded/AutomationSuiteTest.java
@@ -1,4 +1,4 @@
-package org.white_sdev.white_seleniumframework.framework;
+package org.white_sdev.white_seleniumframework.framework.prodexcluded;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.white_sdev.propertiesmanager.model.service.PropertiesManager;
+import org.white_sdev.white_seleniumframework.framework.AutomationScenario;
+import org.white_sdev.white_seleniumframework.framework.AutomationSuite;
+import org.white_sdev.white_seleniumframework.framework.WebDriverUtils;
 
 /**
  * @author <a href="mailto:obed.vazquez@gmail.com">Obed Vazquez</a>

--- a/src/test/java/org/white_sdev/white_seleniumframework/framework/prodexcluded/WebDriverUtilsTest.java
+++ b/src/test/java/org/white_sdev/white_seleniumframework/framework/prodexcluded/WebDriverUtilsTest.java
@@ -1,9 +1,8 @@
-package org.white_sdev.white_seleniumframework.framework;
+package org.white_sdev.white_seleniumframework.framework.prodexcluded;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,6 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openqa.selenium.WebDriver;
 import org.white_sdev.propertiesmanager.model.service.PropertiesManager;
+import org.white_sdev.white_seleniumframework.framework.AutomationScenario;
+import org.white_sdev.white_seleniumframework.framework.AutomationSuite;
+import org.white_sdev.white_seleniumframework.framework.WebDriverUtils;
 
 public class WebDriverUtilsTest {
 	
@@ -41,7 +43,6 @@ public class WebDriverUtilsTest {
 	}
 	
 	@Test
-	@Disabled
 	public void tripleQuittingTest() {
 		AutomationSuite.registerAutomationScenario(new DoubleQuitting());
 		AutomationSuite.launchExecutions();


### PR DESCRIPTION
- Added production profile to maven configurations and activate it on the GitHub action Script to prepare the next stable release and some indications on the POM configuration.
- Excluded the tests to be executed on production due to their instability.